### PR TITLE
Add Jest config and transcription helper test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['/node_modules/', '/.next/'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.425.0",

--- a/src/libs/__tests__/awsTranscriptionHelpers.test.ts
+++ b/src/libs/__tests__/awsTranscriptionHelpers.test.ts
@@ -1,0 +1,20 @@
+import { transcriptionItemsToSrt } from '../awsTranscriptionHelpers';
+
+describe('transcriptionItemsToSrt', () => {
+  it('converts items to SRT', () => {
+    const items = [
+      { start_time: '0.000', end_time: '1.500', content: 'Hello' },
+      { start_time: '1.500', end_time: '3.000', content: 'world' },
+    ];
+
+    const expected =
+      '1\n' +
+      '00:00:00,000 --> 00:00:01,500\n' +
+      'Hello\n\n' +
+      '2\n' +
+      '00:00:01,500 --> 00:00:03,000\n' +
+      'world\n\n';
+
+    expect(transcriptionItemsToSrt(items as any)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- set up basic Jest config with `ts-jest`
- create unit test for `transcriptionItemsToSrt`
- expose `npm test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68875b1ffcb0832787d8ad7ebc314133