### PR TITLE
Fix ffmpeg progress calculations

### DIFF
--- a/src/components/ResultVideo.tsx
+++ b/src/components/ResultVideo.tsx
@@ -54,7 +54,10 @@ export default function ResultVideo({ filename, transcriptionItems }: { filename
       if (regexResult && regexResult?.[1]) {
         const howMuchIsDone = regexResult?.[1];
         const [hours, minutes, seconds] = howMuchIsDone.split(':');
-        const doneTotalSeconds = parseFloat(hours) * 3600 + parseFloat(minutes) * 60 + seconds as any;
+        const doneTotalSeconds =
+          parseFloat(hours) * 3600 +
+          parseFloat(minutes) * 60 +
+          parseFloat(seconds);
         const videoProgress = doneTotalSeconds / duration;
         setProgress(videoProgress);
       }


### PR DESCRIPTION
## Summary
- fix calculation of ffmpeg progress seconds in `ResultVideo`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68872afb4cb083278ab6b398eb8a415a